### PR TITLE
fix(release): bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "ip-location-rs"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "axum",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ip-location-rs"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 authors = ["Nathan Xavier Golez <89695588+neeythann@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
This commit bumps the `Cargo.toml` version to `v0.1.4`