### PR TITLE
fix: bump `Cargo.toml` to `0.2.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "ip-location-rs"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "axum",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ip-location-rs"
-version = "0.1.5"
+version = "0.2.0"
 edition = "2024"
 authors = ["Nathan Xavier Golez <89695588+neeythann@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
Fixes: https://github.com/neeythann/ip-location-rs/issues/31