### PR TITLE
feat: update Docker image from debian bullseye to bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /usr/src/myapp
 COPY . .
 RUN cargo install --path .
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 RUN adduser --disabled-password --gecos '' app
 RUN apt-get update && apt-get install -y wget && rm -rf /var/lib/apt/lists/*
 USER app


### PR DESCRIPTION
Fixes: https://github.com/neeythann/ip-location-rs/issues/42

this commit upgrades the docker image from debian bullseye slim (debian 11) to debian bookworm slim (debian 12)