### PR TITLE
refactor: split src/main.rs into db, models, and handlers modules

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1,0 +1,69 @@
+use crate::models::{Asn, Country};
+use maxminddb::Reader;
+use std::{fmt::Error, net::IpAddr};
+use tokio::sync::OnceCell;
+
+pub static IPV4_COUNTRY: OnceCell<Reader<Vec<u8>>> = OnceCell::const_new();
+pub static IPV4_ASN: OnceCell<Reader<Vec<u8>>> = OnceCell::const_new();
+
+pub static IPV6_COUNTRY: OnceCell<Reader<Vec<u8>>> = OnceCell::const_new();
+pub static IPV6_ASN: OnceCell<Reader<Vec<u8>>> = OnceCell::const_new();
+
+async fn init_reader(path: impl AsRef<std::path::Path>) -> Result<Reader<Vec<u8>>, Error> {
+    let content = tokio::fs::read(path).await.unwrap();
+    let handle = tokio::spawn(async {
+        let reader = maxminddb::Reader::from_source(content).unwrap();
+        return Ok(reader);
+    });
+    handle.await.unwrap()
+}
+
+pub fn get_country(ip: IpAddr) -> Option<Country> {
+    let reader = match ip {
+        IpAddr::V4(_) => IPV4_COUNTRY.get().unwrap(),
+        IpAddr::V6(_) => IPV6_COUNTRY.get().unwrap(),
+    };
+    reader
+        .lookup(ip)
+        .expect("Invalid IP address!")
+        .decode::<Country>()
+        .unwrap()
+}
+
+pub fn get_asn(ip: IpAddr) -> Option<Asn> {
+    let reader = match ip {
+        IpAddr::V4(_) => IPV4_ASN.get().unwrap(),
+        IpAddr::V6(_) => IPV6_ASN.get().unwrap(),
+    };
+    match reader
+        .lookup(ip)
+        .expect("Invalid IP address!")
+        .decode::<Asn>()
+        .unwrap()
+    {
+        Some(mut asn) => {
+            asn.license = Some(String::from("CC BY 4.0 by RouteViews and DB-IP"));
+            asn.modifications = Some(String::from(
+                "https://github.com/sapics/ip-location-db/blob/main/asn/MODIFICATIONS",
+            ));
+            Some(asn)
+        }
+        None => None,
+    }
+}
+
+pub async fn init_mmdb() {
+    // TODO(neeythann): Vector map() (Reader, Path) instead
+    IPV4_COUNTRY
+        .get_or_init(|| async { init_reader("asn-country-ipv4.mmdb").await.unwrap() })
+        .await;
+    IPV4_ASN
+        .get_or_init(|| async { init_reader("asn-ipv4.mmdb").await.unwrap() })
+        .await;
+    IPV6_COUNTRY
+        .get_or_init(|| async { init_reader("asn-country-ipv6.mmdb").await.unwrap() })
+        .await;
+    IPV6_ASN
+        .get_or_init(|| async { init_reader("asn-ipv6.mmdb").await.unwrap() })
+        .await;
+}

--- a/src/handlers/asn.rs
+++ b/src/handlers/asn.rs
@@ -1,0 +1,61 @@
+use crate::db::{IPV4_ASN, IPV6_ASN};
+use crate::models::{Asn, AsnResponse};
+use axum::{Json, extract::Path, http::StatusCode};
+use ipnetwork::IpNetwork;
+use tokio::task::yield_now;
+
+// TODO(neeythann):
+// - validate Path(asn)
+// - cache this result at startup
+pub async fn endpoint_get_asn(Path(asn): Path<usize>) -> Result<Json<AsnResponse>, StatusCode> {
+    let network4: IpNetwork = "0.0.0.0/0".parse().unwrap();
+    let network6: IpNetwork = "::0/0".parse().unwrap();
+    let mut net: Vec<String> = vec![];
+
+    let mut asn_info: Option<Asn> = None;
+
+    let mut iter = IPV4_ASN
+        .get()
+        .unwrap()
+        .within(network4, Default::default())
+        .unwrap();
+    while let Some(next) = iter.next() {
+        let lookup = next.unwrap();
+        let asn_data: Asn = match lookup.decode() {
+            Ok(Some(data)) => data,
+            _ => continue,
+        };
+        if asn_data.autonomous_system_number != asn {
+            continue;
+        }
+
+        if asn_info.is_none() {
+            asn_info = Some(asn_data.clone());
+        }
+        net.push(lookup.network().unwrap().to_string());
+        yield_now().await;
+    }
+    iter = IPV6_ASN
+        .get()
+        .unwrap()
+        .within(network6, Default::default())
+        .unwrap();
+    while let Some(next) = iter.next() {
+        let lookup = next.unwrap();
+        let asn_data: Asn = match lookup.decode() {
+            Ok(Some(data)) => data,
+            _ => continue,
+        };
+        if asn_data.autonomous_system_number != asn {
+            continue;
+        }
+        net.push(lookup.network().unwrap().to_string());
+        yield_now().await;
+    }
+
+    if asn_info.is_none() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    Ok(Json(AsnResponse::new(asn_info.unwrap(), Some(net))))
+}

--- a/src/handlers/country.rs
+++ b/src/handlers/country.rs
@@ -1,0 +1,72 @@
+use crate::db::{IPV4_COUNTRY, IPV6_COUNTRY};
+use crate::models::{Country, CountryResponse};
+use axum::{Json, extract::Path, http::StatusCode};
+use ipnetwork::IpNetwork;
+use tokio::task::yield_now;
+
+// TODO(neeythann):
+// - validate Path(country) with ISO 3166-1 alpha-2
+// - cache this result at startup
+pub async fn endpoint_get_country(
+    Path(country_code): Path<String>,
+) -> Result<Json<CountryResponse>, StatusCode> {
+    if country_code.len() != 2 || !country_code.bytes().all(|c| matches!(c, b'A'..=b'Z')) {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let mut net: Vec<String> = vec![];
+    let mut country_info: Option<Country> = None;
+
+    let network4: IpNetwork = "0.0.0.0/0".parse().unwrap();
+    let mut iter = IPV4_COUNTRY
+        .get()
+        .unwrap()
+        .within(network4, Default::default())
+        .unwrap();
+    while let Some(next) = iter.next() {
+        let lookup = next.unwrap();
+        let country_data: Country = match lookup.decode() {
+            Ok(Some(data)) => data,
+            _ => continue,
+        };
+        if country_data.country_code != country_code {
+            continue;
+        }
+
+        if country_info.is_none() {
+            country_info = Some(country_data);
+        }
+        net.push(lookup.network().unwrap().to_string());
+        yield_now().await;
+    }
+
+    let network6: IpNetwork = "::0/0".parse().unwrap();
+    iter = IPV6_COUNTRY
+        .get()
+        .unwrap()
+        .within(network6, Default::default())
+        .unwrap();
+    while let Some(next) = iter.next() {
+        let lookup = next.unwrap();
+        let country_data: Country = match lookup.decode() {
+            Ok(Some(data)) => data,
+            _ => continue,
+        };
+        if country_data.country_code != country_code {
+            continue;
+        }
+        net.push(lookup.network().unwrap().to_string());
+        yield_now().await;
+    }
+
+    // TODO(neeythann): prematurely check `Path(country)` at the start
+    // if it's an ISO 3166-1 alpha-2 country code
+    if country_info.is_none() {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    Ok(Json(CountryResponse {
+        country: country_info.unwrap(),
+        networks: Some(net),
+    }))
+}

--- a/src/handlers/ip.rs
+++ b/src/handlers/ip.rs
@@ -1,0 +1,68 @@
+use crate::db::{get_asn, get_country};
+use crate::models::RequestedAddress;
+use axum::{
+    Json,
+    extract::{ConnectInfo, Path},
+    http::{HeaderMap, StatusCode},
+};
+use std::net::{IpAddr, SocketAddr};
+
+// SECURITY CONSIDERATION: This microservice is meant to be deployed behind
+// a reverse proxy. Deploying it direcly makes it vulnerable to HTTP Header Injection
+// attacks, which is not (and will not be) supported anytime in the future
+pub async fn index(
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+) -> Result<Json<RequestedAddress>, StatusCode> {
+    let maybe_ip: Option<IpAddr> = match headers.get("X-Real-IP") {
+        Some(ip) => Some(ip.to_str().unwrap().parse().unwrap()),
+        None => None,
+    };
+
+    match maybe_ip {
+        Some(ip) => Ok(Json(RequestedAddress::new(
+            ip,
+            get_country(ip),
+            get_asn(ip),
+        ))),
+        None => Ok(Json(RequestedAddress::new(
+            addr.ip(),
+            get_country(addr.ip()),
+            get_asn(addr.ip()),
+        ))),
+    }
+}
+
+pub async fn endpoint_get_ip(Path(ip): Path<IpAddr>) -> Result<Json<RequestedAddress>, StatusCode> {
+    match ip {
+        IpAddr::V4(ipv4) => {
+            if ipv4.is_loopback()
+                || ipv4.is_private()
+                || ipv4.is_unspecified()
+                || ipv4.is_broadcast()
+            {
+                return Err(StatusCode::UNSUPPORTED_MEDIA_TYPE);
+            }
+            Ok(Json(RequestedAddress {
+                ip,
+                country: get_country(ip),
+                asn: get_asn(ip),
+            }))
+        }
+        IpAddr::V6(ipv6) => {
+            if ipv6.is_loopback()
+                || ipv6.is_multicast()
+                || ipv6.is_unspecified()
+                || ipv6.is_unique_local()
+                || ipv6.is_unicast_link_local()
+            {
+                return Err(StatusCode::UNSUPPORTED_MEDIA_TYPE);
+            }
+            Ok(Json(RequestedAddress {
+                ip,
+                country: get_country(ip),
+                asn: get_asn(ip),
+            }))
+        }
+    }
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,0 +1,3 @@
+pub mod asn;
+pub mod country;
+pub mod ip;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,25 +1,16 @@
-use axum::{
-    Json, Router,
-    extract::{ConnectInfo, Path},
-    http::{HeaderMap, StatusCode},
-    routing::get,
-};
+pub mod db;
+pub mod handlers;
+pub mod models;
+
+use axum::{Router, routing::get};
 use clap::Parser;
-use ipnetwork::IpNetwork;
-use maxminddb::Reader;
-use serde::{Deserialize, Serialize};
-use std::{
-    fmt::Error,
-    net::{IpAddr, SocketAddr},
+use handlers::{
+    asn::endpoint_get_asn,
+    country::endpoint_get_country,
+    ip::{endpoint_get_ip, index},
 };
-use tokio::{sync::OnceCell, task::yield_now};
+use std::net::SocketAddr;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
-
-static IPV4_COUNTRY: OnceCell<Reader<Vec<u8>>> = OnceCell::const_new();
-static IPV4_ASN: OnceCell<Reader<Vec<u8>>> = OnceCell::const_new();
-
-static IPV6_COUNTRY: OnceCell<Reader<Vec<u8>>> = OnceCell::const_new();
-static IPV6_ASN: OnceCell<Reader<Vec<u8>>> = OnceCell::const_new();
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -41,312 +32,6 @@ struct Args {
     listen: SocketAddr,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct Asn {
-    autonomous_system_number: usize,
-    autonomous_system_organization: String,
-    license: Option<String>,
-    modifications: Option<String>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct Country {
-    country_code: String,
-}
-
-#[derive(Serialize)]
-struct RequestedAddress {
-    ip: IpAddr,
-    country: Option<Country>,
-    asn: Option<Asn>,
-}
-
-impl RequestedAddress {
-    pub fn default(ip: IpAddr) -> Self {
-        RequestedAddress {
-            ip,
-            country: None,
-            asn: None,
-        }
-    }
-
-    pub fn new(ip: IpAddr, country: Option<Country>, asn: Option<Asn>) -> Self {
-        let mut rtn = RequestedAddress::default(ip);
-        rtn.country = country;
-        rtn.asn = asn;
-        rtn
-    }
-}
-
-async fn init_reader(path: impl AsRef<std::path::Path>) -> Result<Reader<Vec<u8>>, Error> {
-    let content = tokio::fs::read(path).await.unwrap();
-    let handle = tokio::spawn(async {
-        let reader = maxminddb::Reader::from_source(content).unwrap();
-        return Ok(reader);
-    });
-    handle.await.unwrap()
-}
-
-pub fn get_country(ip: IpAddr) -> Option<Country> {
-    let reader = match ip {
-        IpAddr::V4(_) => IPV4_COUNTRY.get().unwrap(),
-        IpAddr::V6(_) => IPV6_COUNTRY.get().unwrap(),
-    };
-    reader
-        .lookup(ip)
-        .expect("Invalid IP address!")
-        .decode::<Country>()
-        .unwrap()
-}
-
-pub fn get_asn(ip: IpAddr) -> Option<Asn> {
-    let reader = match ip {
-        IpAddr::V4(_) => IPV4_ASN.get().unwrap(),
-        IpAddr::V6(_) => IPV6_ASN.get().unwrap(),
-    };
-    match reader
-        .lookup(ip)
-        .expect("Invalid IP address!")
-        .decode::<Asn>()
-        .unwrap()
-    {
-        Some(mut asn) => {
-            asn.license = Some(String::from("CC BY 4.0 by RouteViews and DB-IP"));
-            asn.modifications = Some(String::from(
-                "https://github.com/sapics/ip-location-db/blob/main/asn/MODIFICATIONS",
-            ));
-            Some(asn)
-        }
-        None => None,
-    }
-}
-
-// TODO(neeythann): refactor this function
-async fn index(
-    ConnectInfo(addr): ConnectInfo<SocketAddr>,
-    headers: HeaderMap,
-) -> Result<Json<RequestedAddress>, StatusCode> {
-    // SECURITY CONSIDERATION: This microservice is meant to be deployed behind
-    // a reverse proxy. Deploying it direcly makes it vulnerable to HTTP Header Injection
-    // attacks, which is not (and will not be) supported anytime in the future
-    let maybe_ip: Option<IpAddr> = match headers.get("X-Real-IP") {
-        Some(ip) => Some(ip.to_str().unwrap().parse().unwrap()),
-        None => None,
-    };
-
-    match maybe_ip {
-        Some(ip) => {
-            return Ok(Json(RequestedAddress::new(
-                ip,
-                get_country(ip),
-                get_asn(ip),
-            )));
-        }
-        None => {
-            return Ok(Json(RequestedAddress::new(
-                addr.ip(),
-                get_country(addr.ip()),
-                get_asn(addr.ip()),
-            )));
-        }
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct AsnResponse {
-    asn: Asn,
-    networks: Option<Vec<String>>,
-}
-
-impl AsnResponse {
-    pub fn default(asn: Asn) -> Self {
-        Self::new(asn, None)
-    }
-
-    pub fn new(asn: Asn, networks: Option<Vec<String>>) -> Self {
-        AsnResponse { asn, networks }
-    }
-}
-
-// TODO(neeythann):
-// - validate Path(asn)
-// - cache this result at startup
-async fn endpoint_get_asn(Path(asn): Path<usize>) -> Result<Json<AsnResponse>, StatusCode> {
-    let network4: IpNetwork = "0.0.0.0/0".parse().unwrap();
-    let network6: IpNetwork = "::0/0".parse().unwrap();
-    let mut net: Vec<String> = vec![];
-
-    let mut asn_info: Option<Asn> = None;
-
-    let mut iter = IPV4_ASN
-        .get()
-        .unwrap()
-        .within(network4, Default::default())
-        .unwrap();
-    while let Some(next) = iter.next() {
-        let lookup = next.unwrap();
-        let asn_data: Asn = match lookup.decode() {
-            Ok(Some(data)) => data,
-            _ => continue,
-        };
-        if asn_data.autonomous_system_number != asn {
-            continue;
-        }
-
-        if asn_info.is_none() {
-            asn_info = Some(asn_data.clone());
-        }
-        net.push(lookup.network().unwrap().to_string());
-        yield_now().await;
-    }
-    iter = IPV6_ASN
-        .get()
-        .unwrap()
-        .within(network6, Default::default())
-        .unwrap();
-    while let Some(next) = iter.next() {
-        let lookup = next.unwrap();
-        let asn_data: Asn = match lookup.decode() {
-            Ok(Some(data)) => data,
-            _ => continue,
-        };
-        if asn_data.autonomous_system_number != asn {
-            continue;
-        }
-        net.push(lookup.network().unwrap().to_string());
-        yield_now().await;
-    }
-
-    if asn_info.is_none() {
-        return Err(StatusCode::BAD_REQUEST);
-    }
-
-    Ok(Json(AsnResponse::new(asn_info.unwrap(), Some(net))))
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct CountryResponse {
-    country: Country,
-    networks: Option<Vec<String>>,
-}
-
-// TODO(neeythann):
-// - validate Path(country) with ISO 3166-1 alpha-2
-// - cache this result at startup
-async fn endpoint_get_country(
-    Path(country_code): Path<String>,
-) -> Result<Json<CountryResponse>, StatusCode> {
-    if country_code.len() != 2 || !country_code.bytes().all(|c| matches!(c, b'A'..=b'Z')) {
-        return Err(StatusCode::BAD_REQUEST);
-    }
-
-    let mut net: Vec<String> = vec![];
-    let mut country_info: Option<Country> = None;
-
-    let network4: IpNetwork = "0.0.0.0/0".parse().unwrap();
-    let mut iter = IPV4_COUNTRY
-        .get()
-        .unwrap()
-        .within(network4, Default::default())
-        .unwrap();
-    while let Some(next) = iter.next() {
-        let lookup = next.unwrap();
-        let country_data: Country = match lookup.decode() {
-            Ok(Some(data)) => data,
-            _ => continue,
-        };
-        if country_data.country_code != country_code {
-            continue;
-        }
-
-        if country_info.is_none() {
-            country_info = Some(country_data);
-        }
-        net.push(lookup.network().unwrap().to_string());
-        yield_now().await;
-    }
-
-    let network6: IpNetwork = "::0/0".parse().unwrap();
-    iter = IPV6_COUNTRY
-        .get()
-        .unwrap()
-        .within(network6, Default::default())
-        .unwrap();
-    while let Some(next) = iter.next() {
-        let lookup = next.unwrap();
-        let country_data: Country = match lookup.decode() {
-            Ok(Some(data)) => data,
-            _ => continue,
-        };
-        if country_data.country_code != country_code {
-            continue;
-        }
-        net.push(lookup.network().unwrap().to_string());
-        yield_now().await;
-    }
-
-    // TODO(neeythann): prematurely check `Path(country)` at the start
-    // if it's an ISO 3166-1 alpha-2 country code
-    if country_info.is_none() {
-        return Err(StatusCode::BAD_REQUEST);
-    }
-
-    Ok(Json(CountryResponse {
-        country: country_info.unwrap(),
-        networks: Some(net),
-    }))
-}
-
-async fn endpoint_get_ip(Path(ip): Path<IpAddr>) -> Result<Json<RequestedAddress>, StatusCode> {
-    match ip {
-        IpAddr::V4(ipv4) => {
-            if ipv4.is_loopback()
-                || ipv4.is_private()
-                || ipv4.is_unspecified()
-                || ipv4.is_broadcast()
-            {
-                return Err(StatusCode::UNSUPPORTED_MEDIA_TYPE);
-            }
-            return Ok(Json(RequestedAddress {
-                ip,
-                country: get_country(ip),
-                asn: get_asn(ip),
-            }));
-        }
-        IpAddr::V6(ipv6) => {
-            if ipv6.is_loopback()
-                || ipv6.is_multicast()
-                || ipv6.is_unspecified()
-                || ipv6.is_unique_local()
-                || ipv6.is_unicast_link_local()
-            {
-                return Err(StatusCode::UNSUPPORTED_MEDIA_TYPE);
-            }
-            return Ok(Json(RequestedAddress {
-                ip,
-                country: get_country(ip),
-                asn: get_asn(ip),
-            }));
-        }
-    }
-}
-
-async fn init_mmdb() {
-    // TODO(neeythann): Vector map() (Reader, Path) instead
-    IPV4_COUNTRY
-        .get_or_init(|| async { init_reader("asn-country-ipv4.mmdb").await.unwrap() })
-        .await;
-    IPV4_ASN
-        .get_or_init(|| async { init_reader("asn-ipv4.mmdb").await.unwrap() })
-        .await;
-    IPV6_COUNTRY
-        .get_or_init(|| async { init_reader("asn-country-ipv6.mmdb").await.unwrap() })
-        .await;
-    IPV6_ASN
-        .get_or_init(|| async { init_reader("asn-ipv6.mmdb").await.unwrap() })
-        .await;
-}
-
 #[tokio::main]
 async fn main() {
     let args = Args::parse();
@@ -356,7 +41,7 @@ async fn main() {
         .init();
     tracing::event!(tracing::Level::INFO, "main");
 
-    init_mmdb().await;
+    db::init_mmdb().await;
 
     let routes = Router::new()
         .route("/", get(index))
@@ -377,24 +62,25 @@ async fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::db::init_mmdb;
+    use crate::handlers::asn::endpoint_get_asn;
+    use crate::handlers::country::endpoint_get_country;
+    use crate::handlers::ip::endpoint_get_ip;
     use axum::{
+        Router,
         body::Body,
-        //extract::connect_info::MockConnectInfo,
         http::{self, Request, StatusCode},
+        routing::get,
     };
-    use tower::{
-        //Service,
-        ServiceExt,
-    }; // for `call`, `oneshot`, and `ready`
+    use tower::ServiceExt; // for `call`, `oneshot`, and `ready`
 
     #[tokio::test]
     async fn oncecell_not_none() {
         init_mmdb().await;
-        IPV4_ASN.get().unwrap();
-        IPV6_ASN.get().unwrap();
-        IPV4_COUNTRY.get().unwrap();
-        IPV6_COUNTRY.get().unwrap();
+        crate::db::IPV4_ASN.get().unwrap();
+        crate::db::IPV6_ASN.get().unwrap();
+        crate::db::IPV4_COUNTRY.get().unwrap();
+        crate::db::IPV6_COUNTRY.get().unwrap();
     }
 
     // TODO(neeythann): Fix failing mock tests
@@ -414,7 +100,7 @@ mod tests {
     //         .uri("/")
     //         .body(Body::empty())
     //         .unwrap();
-
+    //
     //     let response = app.oneshot(request).await.unwrap();
     //     assert_eq!(response.status(), StatusCode::OK)
     // }
@@ -433,7 +119,7 @@ mod tests {
     //         .uri("/")
     //         .body(Body::empty())
     //         .unwrap();
-
+    //
     //     let response = app.ready().await.unwrap().call(request).await.unwrap();
     //     assert_eq!(response.status(), StatusCode::OK)
     // }
@@ -452,7 +138,7 @@ mod tests {
     //         .uri("/")
     //         .body(Body::empty())
     //         .unwrap();
-
+    //
     //     let response = app.oneshot(request).await.unwrap();
     //     assert_eq!(response.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE)
     // }
@@ -471,7 +157,7 @@ mod tests {
     //         .uri("/")
     //         .body(Body::empty())
     //         .unwrap();
-
+    //
     //     let response = app.oneshot(request).await.unwrap();
     //     assert_eq!(response.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE)
     // }

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,0 +1,61 @@
+use serde::{Deserialize, Serialize};
+use std::net::IpAddr;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Asn {
+    pub autonomous_system_number: usize,
+    pub autonomous_system_organization: String,
+    pub license: Option<String>,
+    pub modifications: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Country {
+    pub country_code: String,
+}
+
+#[derive(Serialize)]
+pub struct RequestedAddress {
+    pub ip: IpAddr,
+    pub country: Option<Country>,
+    pub asn: Option<Asn>,
+}
+
+impl RequestedAddress {
+    pub fn default(ip: IpAddr) -> Self {
+        RequestedAddress {
+            ip,
+            country: None,
+            asn: None,
+        }
+    }
+
+    pub fn new(ip: IpAddr, country: Option<Country>, asn: Option<Asn>) -> Self {
+        let mut rtn = RequestedAddress::default(ip);
+        rtn.country = country;
+        rtn.asn = asn;
+        rtn
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct AsnResponse {
+    pub asn: Asn,
+    pub networks: Option<Vec<String>>,
+}
+
+impl AsnResponse {
+    pub fn default(asn: Asn) -> Self {
+        Self::new(asn, None)
+    }
+
+    pub fn new(asn: Asn, networks: Option<Vec<String>>) -> Self {
+        AsnResponse { asn, networks }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct CountryResponse {
+    pub country: Country,
+    pub networks: Option<Vec<String>>,
+}


### PR DESCRIPTION
The single src/main.rs file had grown to contain the CLI args, the MMDB reader statics and initialization, the response structs, and every route handler. Split it into focused modules for readability and to match the already-present (but empty) src/handlers/ directory:

- src/models.rs: Serialize/Deserialize response structs (Asn, Country, RequestedAddress, AsnResponse, CountryResponse) and their constructors.
- src/db.rs: the OnceCell reader statics, init_reader/init_mmdb, and the get_country/get_asn lookup helpers.
- src/handlers/{mod,ip,asn,country}.rs: the axum route handlers split by resource, reusing the shared db and models modules.
- src/main.rs: trimmed to arg parsing, router wiring, the tokio entry point, and the test module which now imports handlers by path.

No behavior changes; the route handlers, lookups, and tests are unchanged aside from import paths. cargo build succeeds and all 12 tests pass under cargo test --all-features.