### PR TITLE
build(deps): bump bytes from 1.10.1 to 1.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,9 +150,9 @@ checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cfg-if"


### PR DESCRIPTION
Updates the transitive `bytes` dependency from 1.10.1 to 1.12.0 in Cargo.lock. `bytes` is not a direct dependency; it is pulled in transitively by axum/hyper/http-body/tokio.

Release notes: https://github.com/tokio-rs/bytes/releases

Verified: `cargo build --release` succeeds.