### PR TITLE
docs: sync README and Dockerfile with current behavior

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ COPY --from=builder /usr/src/myapp/run.sh .
 COPY --from=builder /usr/src/myapp/DBIP-LICENSE .
 COPY --from=builder /usr/src/myapp/ROUTEVIEWS-LICENSE .
 
-EXPOSE 8000
+EXPOSE 80
 CMD ["bash", "./run.sh"]
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It’s designed for high performance, easy deployment, and minimal dependencies.
 
 We provide a [docker image at DockerHub](https://hub.docker.com/r/neeythann/ip-location-rs)
 
-`docker run -d -p 8000:8000 neeythann/ip-location-rs`
+`docker run -d -p 8000:80 neeythann/ip-location-rs`
 
 ### Kubernetes
 
@@ -41,7 +41,7 @@ For more information, please see the [openapi.yaml file spec](https://github.com
 ### Sample Usage
 
 ```bash
-curl -s http://localhost:80/ -H 'X-Forwarded-For: 1.1.1.1' | jq
+curl -s http://localhost:80/ -H 'X-Real-IP: 1.1.1.1' | jq
 ```
 
 Which outputs:


### PR DESCRIPTION
- Update docker run port mapping from 8000:8000 to 8000:80 to match the default listen address changed in d14e15b (fix: change socket to 0.0.0.0:80). The container's internal port is 80, not 8000.
- Update sample curl to use the X-Real-IP header instead of X-Forwarded-For, matching the index handler in src/handlers/ip.rs which reads X-Real-IP since 3495fae (fix: favor X-Real-IP over X-Forwarded-For).
- Update Dockerfile EXPOSE from 8000 to 80 for consistency with the actual listening port. EXPOSE is informational only, but keeping it accurate avoids misleading users.