### PR TITLE
fix: enable and repair index endpoint mock tests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -65,13 +65,15 @@ mod tests {
     use crate::db::init_mmdb;
     use crate::handlers::asn::endpoint_get_asn;
     use crate::handlers::country::endpoint_get_country;
-    use crate::handlers::ip::endpoint_get_ip;
+    use crate::handlers::ip::{endpoint_get_ip, index};
     use axum::{
         Router,
         body::Body,
+        extract::connect_info::MockConnectInfo,
         http::{self, Request, StatusCode},
         routing::get,
     };
+    use std::net::SocketAddr;
     use tower::ServiceExt; // for `call`, `oneshot`, and `ready`
 
     #[tokio::test]
@@ -83,84 +85,90 @@ mod tests {
         crate::db::IPV6_COUNTRY.get().unwrap();
     }
 
-    // TODO(neeythann): Fix failing mock tests
-    // Tracked in: https://github.com/neeythann/ip-location-rs/issues/29
+    // The `index` handler favors the `X-Real-IP` header and falls back to the
+    // connected socket address when it is absent. See issue #29 for history.
 
-    // #[tokio::test]
-    // async fn index_header_xforwardedfor_ip_ipv4() {
-    //     init_mmdb().await;
-    //     let app = Router::new()
-    //         .route("/", get(index))
-    //         .layer(MockConnectInfo("127.0.0.1:8000".parse::<SocketAddr>()))
-    //         .into_service();
-    //     let request = Request::builder()
-    //         .method(http::Method::GET)
-    //         .header("Accept", "*/*")
-    //         .header("X-Forwarded-For", "1.1.1.1")
-    //         .uri("/")
-    //         .body(Body::empty())
-    //         .unwrap();
-    //
-    //     let response = app.oneshot(request).await.unwrap();
-    //     assert_eq!(response.status(), StatusCode::OK)
-    // }
+    #[tokio::test]
+    async fn index_header_x_real_ip_ipv4() {
+        init_mmdb().await;
+        let app = Router::new()
+            .route("/", get(index))
+            .layer(MockConnectInfo(
+                "127.0.0.1:8000".parse::<SocketAddr>().unwrap(),
+            ))
+            .into_service::<Body>();
+        let request = Request::builder()
+            .method(http::Method::GET)
+            .header("Accept", "*/*")
+            .header("X-Real-IP", "1.1.1.1")
+            .uri("/")
+            .body(Body::empty())
+            .unwrap();
 
-    // #[tokio::test]
-    // async fn index_header_xforwardedfor_ip_ipv6() {
-    //     init_mmdb().await;
-    //     let mut app = Router::new()
-    //         .route("/", get(index))
-    //         .layer(MockConnectInfo("127.0.0.1:8000".parse::<SocketAddr>()))
-    //         .into_service::<Body>();
-    //     let request = Request::builder()
-    //         .method(http::Method::GET)
-    //         .header("Accept", "*/*")
-    //         .header("X-Forwarded-For", "2606:4700:4700::1111")
-    //         .uri("/")
-    //         .body(Body::empty())
-    //         .unwrap();
-    //
-    //     let response = app.ready().await.unwrap().call(request).await.unwrap();
-    //     assert_eq!(response.status(), StatusCode::OK)
-    // }
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK)
+    }
 
-    // #[tokio::test]
-    // async fn index_header_cfconnectingip_ip_ipv4() {
-    //     init_mmdb().await;
-    //     let app = Router::new()
-    //         .route("/", get(index))
-    //         .layer(MockConnectInfo("127.0.0.1:8000".parse::<SocketAddr>()))
-    //         .into_service::<Body>();
-    //     let request = Request::builder()
-    //         .method(http::Method::GET)
-    //         .header("Accept", "*/*")
-    //         .header("CF-Connecting-IP", "1.1.1.1")
-    //         .uri("/")
-    //         .body(Body::empty())
-    //         .unwrap();
-    //
-    //     let response = app.oneshot(request).await.unwrap();
-    //     assert_eq!(response.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE)
-    // }
+    #[tokio::test]
+    async fn index_header_x_real_ip_ipv6() {
+        init_mmdb().await;
+        let app = Router::new()
+            .route("/", get(index))
+            .layer(MockConnectInfo(
+                "127.0.0.1:8000".parse::<SocketAddr>().unwrap(),
+            ))
+            .into_service::<Body>();
+        let request = Request::builder()
+            .method(http::Method::GET)
+            .header("Accept", "*/*")
+            .header("X-Real-IP", "2606:4700:4700::1111")
+            .uri("/")
+            .body(Body::empty())
+            .unwrap();
 
-    // #[tokio::test]
-    // async fn index_header_cfconnectingip_ip_ipv6() {
-    //     init_mmdb().await;
-    //     let app = Router::new()
-    //         .route("/", get(index))
-    //         .layer(MockConnectInfo("127.0.0.1".parse::<SocketAddr>()))
-    //         .into_service::<Body>();
-    //     let request = Request::builder()
-    //         .method(http::Method::GET)
-    //         .header("Accept", "*/*")
-    //         .header("CF-Connecting-IP", "2606:4700:4700::1111")
-    //         .uri("/")
-    //         .body(Body::empty())
-    //         .unwrap();
-    //
-    //     let response = app.oneshot(request).await.unwrap();
-    //     assert_eq!(response.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE)
-    // }
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK)
+    }
+
+    #[tokio::test]
+    async fn index_no_header_fallback_ipv4() {
+        init_mmdb().await;
+        let app = Router::new()
+            .route("/", get(index))
+            .layer(MockConnectInfo(
+                "1.1.1.1:8000".parse::<SocketAddr>().unwrap(),
+            ))
+            .into_service::<Body>();
+        let request = Request::builder()
+            .method(http::Method::GET)
+            .header("Accept", "*/*")
+            .uri("/")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK)
+    }
+
+    #[tokio::test]
+    async fn index_no_header_fallback_ipv6() {
+        init_mmdb().await;
+        let app = Router::new()
+            .route("/", get(index))
+            .layer(MockConnectInfo(
+                "[2606:4700:4700::1111]:8000".parse::<SocketAddr>().unwrap(),
+            ))
+            .into_service::<Body>();
+        let request = Request::builder()
+            .method(http::Method::GET)
+            .header("Accept", "*/*")
+            .uri("/")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK)
+    }
 
     #[tokio::test]
     async fn asn_valid() {


### PR DESCRIPTION
The four index endpoint tests were disabled in #47 because they failed to compile and no longer matched handler behavior. They are now rewritten and enabled:

- Import MockConnectInfo from axum::extract::connect_info (the type was referenced but never imported, and parse::<SocketAddr>() returns a Result that must be unwrapped).
- Drop the obsolete X-Forwarded-For / CF-Connecting-IP header cases. Commit 3495fae changed the handler to read only X-Real-IP, so those headers are ignored and the previous 415 expectations are no longer reachable; the handler now always returns 200.
- Replace them with four tests covering the current behavior: X-Real-IP with an IPv4/IPv6 address (header takes precedence), and the fallback to the connected socket address for IPv4/IPv6 when the header is absent.

All 16 tests pass (cargo test --all-features) and cargo fmt --check is clean. The pre-existing clippy warnings in handlers/ip.rs and main are unrelated to this change and left untouched.

Closes #29.