### PR TITLE
perf: cache /country/{country_code} responses at startup

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1,6 +1,6 @@
-use crate::models::{Asn, Country};
+use crate::models::{Asn, Country, CountryResponse};
 use maxminddb::Reader;
-use std::{fmt::Error, net::IpAddr};
+use std::{collections::HashMap, fmt::Error, net::IpAddr};
 use tokio::sync::OnceCell;
 
 pub static IPV4_COUNTRY: OnceCell<Reader<Vec<u8>>> = OnceCell::const_new();
@@ -8,6 +8,8 @@ pub static IPV4_ASN: OnceCell<Reader<Vec<u8>>> = OnceCell::const_new();
 
 pub static IPV6_COUNTRY: OnceCell<Reader<Vec<u8>>> = OnceCell::const_new();
 pub static IPV6_ASN: OnceCell<Reader<Vec<u8>>> = OnceCell::const_new();
+
+pub static COUNTRY_CACHE: OnceCell<HashMap<String, CountryResponse>> = OnceCell::const_new();
 
 async fn init_reader(path: impl AsRef<std::path::Path>) -> Result<Reader<Vec<u8>>, Error> {
     let content = tokio::fs::read(path).await.unwrap();
@@ -65,5 +67,67 @@ pub async fn init_mmdb() {
         .await;
     IPV6_ASN
         .get_or_init(|| async { init_reader("asn-ipv6.mmdb").await.unwrap() })
+        .await;
+}
+
+pub async fn init_country_cache() {
+    COUNTRY_CACHE
+        .get_or_init(|| async {
+            let mut cache: HashMap<String, CountryResponse> = HashMap::new();
+
+            let network4: ipnetwork::IpNetwork = "0.0.0.0/0".parse().unwrap();
+            let mut iter = IPV4_COUNTRY
+                .get()
+                .unwrap()
+                .within(network4, Default::default())
+                .unwrap();
+            while let Some(next) = iter.next() {
+                let lookup = next.unwrap();
+                let country_data: Country = match lookup.decode() {
+                    Ok(Some(data)) => data,
+                    _ => continue,
+                };
+                let network = lookup.network().unwrap().to_string();
+                cache
+                    .entry(country_data.country_code.clone())
+                    .and_modify(|resp| {
+                        if let Some(nets) = resp.networks.as_mut() {
+                            nets.push(network.clone());
+                        }
+                    })
+                    .or_insert_with(|| CountryResponse {
+                        country: country_data,
+                        networks: Some(vec![network]),
+                    });
+            }
+
+            let network6: ipnetwork::IpNetwork = "::0/0".parse().unwrap();
+            iter = IPV6_COUNTRY
+                .get()
+                .unwrap()
+                .within(network6, Default::default())
+                .unwrap();
+            while let Some(next) = iter.next() {
+                let lookup = next.unwrap();
+                let country_data: Country = match lookup.decode() {
+                    Ok(Some(data)) => data,
+                    _ => continue,
+                };
+                let network = lookup.network().unwrap().to_string();
+                cache
+                    .entry(country_data.country_code.clone())
+                    .and_modify(|resp| {
+                        if let Some(nets) = resp.networks.as_mut() {
+                            nets.push(network.clone());
+                        }
+                    })
+                    .or_insert_with(|| CountryResponse {
+                        country: country_data,
+                        networks: Some(vec![network]),
+                    });
+            }
+
+            cache
+        })
         .await;
 }

--- a/src/handlers/country.rs
+++ b/src/handlers/country.rs
@@ -1,12 +1,7 @@
-use crate::db::{IPV4_COUNTRY, IPV6_COUNTRY};
-use crate::models::{Country, CountryResponse};
+use crate::db::COUNTRY_CACHE;
+use crate::models::CountryResponse;
 use axum::{Json, extract::Path, http::StatusCode};
-use ipnetwork::IpNetwork;
-use tokio::task::yield_now;
 
-// TODO(neeythann):
-// - validate Path(country) with ISO 3166-1 alpha-2
-// - cache this result at startup
 pub async fn endpoint_get_country(
     Path(country_code): Path<String>,
 ) -> Result<Json<CountryResponse>, StatusCode> {
@@ -14,59 +9,8 @@ pub async fn endpoint_get_country(
         return Err(StatusCode::BAD_REQUEST);
     }
 
-    let mut net: Vec<String> = vec![];
-    let mut country_info: Option<Country> = None;
-
-    let network4: IpNetwork = "0.0.0.0/0".parse().unwrap();
-    let mut iter = IPV4_COUNTRY
-        .get()
-        .unwrap()
-        .within(network4, Default::default())
-        .unwrap();
-    while let Some(next) = iter.next() {
-        let lookup = next.unwrap();
-        let country_data: Country = match lookup.decode() {
-            Ok(Some(data)) => data,
-            _ => continue,
-        };
-        if country_data.country_code != country_code {
-            continue;
-        }
-
-        if country_info.is_none() {
-            country_info = Some(country_data);
-        }
-        net.push(lookup.network().unwrap().to_string());
-        yield_now().await;
+    match COUNTRY_CACHE.get().unwrap().get(&country_code) {
+        Some(resp) => Ok(Json(resp.clone())),
+        None => Err(StatusCode::BAD_REQUEST),
     }
-
-    let network6: IpNetwork = "::0/0".parse().unwrap();
-    iter = IPV6_COUNTRY
-        .get()
-        .unwrap()
-        .within(network6, Default::default())
-        .unwrap();
-    while let Some(next) = iter.next() {
-        let lookup = next.unwrap();
-        let country_data: Country = match lookup.decode() {
-            Ok(Some(data)) => data,
-            _ => continue,
-        };
-        if country_data.country_code != country_code {
-            continue;
-        }
-        net.push(lookup.network().unwrap().to_string());
-        yield_now().await;
-    }
-
-    // TODO(neeythann): prematurely check `Path(country)` at the start
-    // if it's an ISO 3166-1 alpha-2 country code
-    if country_info.is_none() {
-        return Err(StatusCode::BAD_REQUEST);
-    }
-
-    Ok(Json(CountryResponse {
-        country: country_info.unwrap(),
-        networks: Some(net),
-    }))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,7 @@ async fn main() {
     tracing::event!(tracing::Level::INFO, "main");
 
     db::init_mmdb().await;
+    db::init_country_cache().await;
 
     let routes = Router::new()
         .route("/", get(index))
@@ -271,6 +272,7 @@ mod tests {
     #[tokio::test]
     async fn country_valid() {
         init_mmdb().await;
+        crate::db::init_country_cache().await;
         let app = Router::new()
             .route("/country/{country_code}", get(endpoint_get_country))
             .into_service::<Body>();

--- a/src/models.rs
+++ b/src/models.rs
@@ -9,7 +9,7 @@ pub struct Asn {
     pub modifications: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Country {
     pub country_code: String,
 }
@@ -54,7 +54,7 @@ impl AsnResponse {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct CountryResponse {
     pub country: Country,
     pub networks: Option<Vec<String>>,


### PR DESCRIPTION
Precompute a HashMap<country_code, CountryResponse> in a OnceCell during startup instead of scanning both MMDB databases on every request. The previous handler walked 0.0.0.0/0 and ::0/0 via within(...) and decoded every entry to filter by country code, which made each request O(N) over the full dataset.

Changes:
- Add COUNTRY_CACHE static and init_country_cache() in db.rs that builds the map from a single pass over IPV4_COUNTRY and IPV6_COUNTRY, merging networks per country via entry().and_modify()/or_insert_with()
- Call init_country_cache() after init_mmdb() in main.rs
- Rewrite endpoint_get_country to do an O(1) HashMap lookup and return a cloned CountryResponse, dropping the per-request scan
- Derive Clone on Country and CountryResponse so cached values can be served without re-decoding
- Initialize the cache in the country_valid test
- Remove stale TODO comments about caching at startup