### PR TITLE
build: publish multi-architecture image (linux/amd64, linux/arm64)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
@@ -25,6 +28,8 @@ jobs:
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
+          provenance: false
           push: true
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/ip-location-rs:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,42 @@
-FROM rust:1.85-bullseye AS builder
+FROM --platform=$BUILDPLATFORM rust:1.85-bullseye AS builder
+ARG TARGETPLATFORM
 WORKDIR /usr/src/myapp
 COPY . .
-RUN cargo install --path .
+
+# Install the arm64 cross-linker and Rust target only when building for arm64.
+# The builder stage itself always runs on the runner's native arch ($BUILDPLATFORM),
+# so cargo compiles natively without QEMU emulation regardless of the target.
+RUN case "$TARGETPLATFORM" in \
+      linux/arm64) \
+        apt-get update && apt-get install -y --no-install-recommends \
+          gcc-aarch64-linux-gnu \
+          libc6-dev-arm64-cross && \
+        rustup target add aarch64-unknown-linux-gnu ;; \
+    esac
+
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+
+# Build for the requested target arch and normalise the binary path so the
+# runtime stage's COPY is arch-agnostic.
+RUN case "$TARGETPLATFORM" in \
+      linux/arm64) \
+        cargo build --release --target aarch64-unknown-linux-gnu && \
+        cp target/aarch64-unknown-linux-gnu/release/ip-location-rs \
+           /usr/src/myapp/ip-location-rs-bin ;; \
+      *) \
+        cargo build --release && \
+        cp target/release/ip-location-rs /usr/src/myapp/ip-location-rs-bin ;; \
+    esac
 
 FROM debian:bookworm-slim
 RUN adduser --disabled-password --gecos '' app
 RUN apt-get update && apt-get install -y wget && rm -rf /var/lib/apt/lists/*
 USER app
 WORKDIR /app
-COPY --from=builder /usr/local/cargo/bin/ip-location-rs .
+COPY --from=builder /usr/src/myapp/ip-location-rs-bin /app/ip-location-rs
 COPY --from=builder /usr/src/myapp/run.sh .
 COPY --from=builder /usr/src/myapp/DBIP-LICENSE .
 COPY --from=builder /usr/src/myapp/ROUTEVIEWS-LICENSE .
 
 EXPOSE 80
 CMD ["bash", "./run.sh"]
-

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ We provide a [docker image at DockerHub](https://hub.docker.com/r/neeythann/ip-l
 
 `docker run -d -p 8000:80 neeythann/ip-location-rs`
 
+The published image is a multi-architecture manifest supporting `linux/amd64` and `linux/arm64`, so Docker automatically pulls the matching architecture on x86_64 hosts and 64-bit ARM hosts (e.g. AWS Graviton, Apple Silicon, Raspberry Pi 4/5 running a 64-bit OS).
+
 ### Kubernetes
 
 A sample ArgoCD Kubernetes application, deployment, and service manifests can be found in the `manifests/` folder.


### PR DESCRIPTION
Cross-compile arm64 on the native amd64 runner instead of emulating the full Rust build under QEMU, which keeps release builds fast (~minutes rather than 20-45 min) and avoids Actions timeouts.

Dockerfile:
- Pin the builder stage to $BUILDPLATFORM so cargo always runs on the runner's native arch; select the target via the buildx-injected TARGETPLATFORM arg.
- For linux/arm64, install gcc-aarch64-linux-gnu + libc6-dev-arm64-cross and the aarch64-unknown-linux-gnu rustup target, then build with CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER set.
- Switch from `cargo install --path .` to `cargo build --release` (+ cp to a normalised ip-location-rs-bin path) so the runtime stage's COPY is arch-agnostic. Pure-Rust deps (axum, tokio, maxminddb, clap, serde, ipnetwork, tracing) need no C-sysroot cross-compile handling.
- Runtime stage is unchanged; the bullseye-built binary runs fine on bookworm-slim (newer glibc is backwards-compatible).

release.yaml:
- Add docker/setup-qemu-action@v4.2.0 (needed for the runtime stage's arm64 apt-get; the heavy cargo compile stays native).
- Set `platforms: linux/amd64,linux/arm64` and `provenance: false` on docker/build-push-action for a clean multi-arch manifest.

README.md:
- Note that the published image supports amd64 and arm64.

Closes #62