### PR TITLE
feat: add --proxy flag to select client IP header on index endpoint

### DIFF
--- a/src/handlers/ip.rs
+++ b/src/handlers/ip.rs
@@ -1,7 +1,8 @@
 use crate::db::{get_asn, get_country};
 use crate::models::RequestedAddress;
+use crate::ProxyType;
 use axum::{
-    Json,
+    Extension, Json,
     extract::{ConnectInfo, Path},
     http::{HeaderMap, StatusCode},
 };
@@ -9,28 +10,25 @@ use std::net::{IpAddr, SocketAddr};
 
 // SECURITY CONSIDERATION: This microservice is meant to be deployed behind
 // a reverse proxy. Deploying it direcly makes it vulnerable to HTTP Header Injection
-// attacks, which is not (and will not be) supported anytime in the future
+// attacks, which is not (and will not be) supported anytime in the future.
+//
+// Which header (if any) is trusted for the client's real IP is controlled by
+// the `--proxy` CLI flag (see `ProxyType` in `main.rs`). When the selected
+// header is absent or malformed the handler falls back to the connected
+// socket address rather than erroring, so a misconfigured proxy never turns
+// a successful lookup into a 4xx/5xx.
 pub async fn index(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    Extension(proxy): Extension<ProxyType>,
     headers: HeaderMap,
 ) -> Result<Json<RequestedAddress>, StatusCode> {
-    let maybe_ip: Option<IpAddr> = match headers.get("X-Real-IP") {
-        Some(ip) => Some(ip.to_str().unwrap().parse().unwrap()),
-        None => None,
-    };
+    let ip = proxy.client_ip(&headers).unwrap_or_else(|| addr.ip());
 
-    match maybe_ip {
-        Some(ip) => Ok(Json(RequestedAddress::new(
-            ip,
-            get_country(ip),
-            get_asn(ip),
-        ))),
-        None => Ok(Json(RequestedAddress::new(
-            addr.ip(),
-            get_country(addr.ip()),
-            get_asn(addr.ip()),
-        ))),
-    }
+    Ok(Json(RequestedAddress::new(
+        ip,
+        get_country(ip),
+        get_asn(ip),
+    )))
 }
 
 pub async fn endpoint_get_ip(Path(ip): Path<IpAddr>) -> Result<Json<RequestedAddress>, StatusCode> {

--- a/src/handlers/ip.rs
+++ b/src/handlers/ip.rs
@@ -1,6 +1,6 @@
+use crate::ProxyType;
 use crate::db::{get_asn, get_country};
 use crate::models::RequestedAddress;
-use crate::ProxyType;
 use axum::{
     Extension, Json,
     extract::{ConnectInfo, Path},

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,15 +2,58 @@ pub mod db;
 pub mod handlers;
 pub mod models;
 
-use axum::{Router, routing::get};
-use clap::Parser;
+use axum::{
+    Extension, Router, routing::get,
+    http::HeaderMap,
+};
+use clap::{Parser, ValueEnum};
 use handlers::{
     asn::endpoint_get_asn,
     country::endpoint_get_country,
     ip::{endpoint_get_ip, index},
 };
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum ProxyType {
+    /// Read the client IP from the `CF-Connecting-IP` header (Cloudflare).
+    #[value(name = "cf-connecting-ip")]
+    CfConnectingIp,
+    /// Read the client IP from the leftmost entry of the `X-Forwarded-For` header.
+    #[value(name = "x-forwarded-for")]
+    XForwardedFor,
+    /// Read the client IP from the `X-Real-IP` header.
+    #[value(name = "x-real-ip")]
+    XRealIp,
+    /// Ignore all headers and use the connected socket address.
+    #[value(name = "none")]
+    None,
+}
+
+impl ProxyType {
+    /// Returns the configured client IP, falling back to `None` (caller should
+    /// use the connected socket address) when the selected header is absent or
+    /// holds a value that is not a valid `IpAddr`.
+    pub fn client_ip(self, headers: &HeaderMap) -> Option<IpAddr> {
+        let header_name = match self {
+            ProxyType::CfConnectingIp => "CF-Connecting-IP",
+            ProxyType::XForwardedFor => "X-Forwarded-For",
+            ProxyType::XRealIp => "X-Real-IP",
+            ProxyType::None => return None,
+        };
+
+        let value = headers.get(header_name)?.to_str().ok()?;
+        let candidate = match self {
+            // X-Forwarded-For is a comma-separated list; the leftmost entry is
+            // the original client. Trusted proxies are expected to strip
+            // spoofed leftmost values.
+            ProxyType::XForwardedFor => value.split(',').next()?.trim(),
+            _ => value.trim(),
+        };
+        candidate.parse().ok()
+    }
+}
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -30,6 +73,17 @@ struct Args {
         help = "A socket to listen for the server"
     )]
     listen: SocketAddr,
+
+    #[arg(
+        short,
+        long,
+        value_enum,
+        default_value_t = ProxyType::XRealIp,
+        help = "Which request header to trust for the client's real IP on the \
+                index endpoint (also accepts `none` to ignore headers and use \
+                the socket address)"
+    )]
+    proxy: ProxyType,
 }
 
 #[tokio::main]
@@ -48,7 +102,8 @@ async fn main() {
         .route("/", get(index))
         .route("/ip/{ip_address}", get(endpoint_get_ip))
         .route("/AS/{asn}", get(endpoint_get_asn))
-        .route("/country/{country_code}", get(endpoint_get_country));
+        .route("/country/{country_code}", get(endpoint_get_country))
+        .layer(Extension(args.proxy));
 
     // placeholder for now
     if args.experimental {}
@@ -67,8 +122,9 @@ mod tests {
     use crate::handlers::asn::endpoint_get_asn;
     use crate::handlers::country::endpoint_get_country;
     use crate::handlers::ip::{endpoint_get_ip, index};
+    use crate::ProxyType;
     use axum::{
-        Router,
+        Extension, Router,
         body::Body,
         extract::connect_info::MockConnectInfo,
         http::{self, Request, StatusCode},
@@ -86,8 +142,10 @@ mod tests {
         crate::db::IPV6_COUNTRY.get().unwrap();
     }
 
-    // The `index` handler favors the `X-Real-IP` header and falls back to the
-    // connected socket address when it is absent. See issue #29 for history.
+    // The `index` handler reads the client IP from the header selected by the
+    // `--proxy` flag (`X-Real-IP` by default) and falls back to the connected
+    // socket address when that header is absent or malformed. See issues #29
+    // and #38 for history.
 
     #[tokio::test]
     async fn index_header_x_real_ip_ipv4() {
@@ -97,6 +155,7 @@ mod tests {
             .layer(MockConnectInfo(
                 "127.0.0.1:8000".parse::<SocketAddr>().unwrap(),
             ))
+            .layer(Extension(ProxyType::XRealIp))
             .into_service::<Body>();
         let request = Request::builder()
             .method(http::Method::GET)
@@ -118,6 +177,7 @@ mod tests {
             .layer(MockConnectInfo(
                 "127.0.0.1:8000".parse::<SocketAddr>().unwrap(),
             ))
+            .layer(Extension(ProxyType::XRealIp))
             .into_service::<Body>();
         let request = Request::builder()
             .method(http::Method::GET)
@@ -139,6 +199,7 @@ mod tests {
             .layer(MockConnectInfo(
                 "1.1.1.1:8000".parse::<SocketAddr>().unwrap(),
             ))
+            .layer(Extension(ProxyType::XRealIp))
             .into_service::<Body>();
         let request = Request::builder()
             .method(http::Method::GET)
@@ -159,6 +220,7 @@ mod tests {
             .layer(MockConnectInfo(
                 "[2606:4700:4700::1111]:8000".parse::<SocketAddr>().unwrap(),
             ))
+            .layer(Extension(ProxyType::XRealIp))
             .into_service::<Body>();
         let request = Request::builder()
             .method(http::Method::GET)
@@ -171,10 +233,11 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK)
     }
 
-    // `CF-Connecting-IP` is intentionally ignored by the `index` handler,
-    // which only honors `X-Real-IP` (and otherwise falls back to the socket
-    // address). These tests confirm the header does not cause an error and
-    // is not required for the request to succeed.
+    // When `--proxy x-real-ip` (the default) is set, `CF-Connecting-IP` is
+    // intentionally ignored by the `index` handler, which honors only the
+    // selected header (and otherwise falls back to the socket address). These
+    // tests confirm the header does not cause an error and is not required for
+    // the request to succeed.
 
     #[tokio::test]
     async fn index_header_cfconnectingip_ip_ipv4() {
@@ -184,6 +247,7 @@ mod tests {
             .layer(MockConnectInfo(
                 "1.1.1.1:8000".parse::<SocketAddr>().unwrap(),
             ))
+            .layer(Extension(ProxyType::XRealIp))
             .into_service::<Body>();
         let request = Request::builder()
             .method(http::Method::GET)
@@ -205,11 +269,163 @@ mod tests {
             .layer(MockConnectInfo(
                 "[2606:4700:4700::1111]:8000".parse::<SocketAddr>().unwrap(),
             ))
+            .layer(Extension(ProxyType::XRealIp))
             .into_service::<Body>();
         let request = Request::builder()
             .method(http::Method::GET)
             .header("Accept", "*/*")
             .header("CF-Connecting-IP", "2001:4860:4860::8888")
+            .uri("/")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK)
+    }
+
+    // When `--proxy cf-connecting-ip` is set, the `index` handler reads the
+    // client IP from `CF-Connecting-IP` and falls back to the socket address
+    // when that header is absent or malformed.
+
+    #[tokio::test]
+    async fn index_proxy_cf_connecting_ip_ipv4() {
+        init_mmdb().await;
+        let app = Router::new()
+            .route("/", get(index))
+            .layer(MockConnectInfo(
+                "127.0.0.1:8000".parse::<SocketAddr>().unwrap(),
+            ))
+            .layer(Extension(ProxyType::CfConnectingIp))
+            .into_service::<Body>();
+        let request = Request::builder()
+            .method(http::Method::GET)
+            .header("Accept", "*/*")
+            .header("CF-Connecting-IP", "1.1.1.1")
+            .uri("/")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK)
+    }
+
+    #[tokio::test]
+    async fn index_proxy_cf_connecting_ip_ipv6() {
+        init_mmdb().await;
+        let app = Router::new()
+            .route("/", get(index))
+            .layer(MockConnectInfo(
+                "127.0.0.1:8000".parse::<SocketAddr>().unwrap(),
+            ))
+            .layer(Extension(ProxyType::CfConnectingIp))
+            .into_service::<Body>();
+        let request = Request::builder()
+            .method(http::Method::GET)
+            .header("Accept", "*/*")
+            .header("CF-Connecting-IP", "2606:4700:4700::1111")
+            .uri("/")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK)
+    }
+
+    // When `--proxy x-forwarded-for` is set, the `index` handler reads the
+    // leftmost entry of the comma-separated `X-Forwarded-For` list and falls
+    // back to the socket address when the header is absent or malformed.
+
+    #[tokio::test]
+    async fn index_proxy_x_forwarded_for_single() {
+        init_mmdb().await;
+        let app = Router::new()
+            .route("/", get(index))
+            .layer(MockConnectInfo(
+                "127.0.0.1:8000".parse::<SocketAddr>().unwrap(),
+            ))
+            .layer(Extension(ProxyType::XForwardedFor))
+            .into_service::<Body>();
+        let request = Request::builder()
+            .method(http::Method::GET)
+            .header("Accept", "*/*")
+            .header("X-Forwarded-For", "1.1.1.1")
+            .uri("/")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK)
+    }
+
+    #[tokio::test]
+    async fn index_proxy_x_forwarded_for_multi() {
+        init_mmdb().await;
+        let app = Router::new()
+            .route("/", get(index))
+            .layer(MockConnectInfo(
+                "127.0.0.1:8000".parse::<SocketAddr>().unwrap(),
+            ))
+            .layer(Extension(ProxyType::XForwardedFor))
+            .into_service::<Body>();
+        let request = Request::builder()
+            .method(http::Method::GET)
+            .header("Accept", "*/*")
+            .header("X-Forwarded-For", "1.1.1.1, 10.0.0.1, 192.168.1.1")
+            .uri("/")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK)
+    }
+
+    // When `--proxy none` is set, the `index` handler ignores every header
+    // and uses the connected socket address, even if a normally-trusted header
+    // such as `X-Real-IP` is present.
+
+    #[tokio::test]
+    async fn index_proxy_none_ignores_headers() {
+        init_mmdb().await;
+        let app = Router::new()
+            .route("/", get(index))
+            .layer(MockConnectInfo(
+                "1.1.1.1:8000".parse::<SocketAddr>().unwrap(),
+            ))
+            .layer(Extension(ProxyType::None))
+            .into_service::<Body>();
+        let request = Request::builder()
+            .method(http::Method::GET)
+            .header("Accept", "*/*")
+            .header("X-Real-IP", "8.8.8.8")
+            .header("CF-Connecting-IP", "8.8.4.4")
+            .header("X-Forwarded-For", "203.0.113.1")
+            .uri("/")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK)
+    }
+
+    // A malformed value in the selected header must not panic the request
+    // task; the handler falls back to the connected socket address instead.
+    // This is the regression that motivates removing the previous `.unwrap()`
+    // calls in the `index` handler.
+
+    #[tokio::test]
+    async fn index_proxy_malformed_header_falls_back() {
+        init_mmdb().await;
+        let app = Router::new()
+            .route("/", get(index))
+            .layer(MockConnectInfo(
+                "1.1.1.1:8000".parse::<SocketAddr>().unwrap(),
+            ))
+            .layer(Extension(ProxyType::XRealIp))
+            .into_service::<Body>();
+        let request = Request::builder()
+            .method(http::Method::GET)
+            .header("Accept", "*/*")
+            .header("X-Real-IP", "not-an-ip")
             .uri("/")
             .body(Body::empty())
             .unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,7 @@ pub mod db;
 pub mod handlers;
 pub mod models;
 
-use axum::{
-    Extension, Router, routing::get,
-    http::HeaderMap,
-};
+use axum::{Extension, Router, http::HeaderMap, routing::get};
 use clap::{Parser, ValueEnum};
 use handlers::{
     asn::endpoint_get_asn,
@@ -118,11 +115,11 @@ async fn main() {
 
 #[cfg(test)]
 mod tests {
+    use crate::ProxyType;
     use crate::db::init_mmdb;
     use crate::handlers::asn::endpoint_get_asn;
     use crate::handlers::country::endpoint_get_country;
     use crate::handlers::ip::{endpoint_get_ip, index};
-    use crate::ProxyType;
     use axum::{
         Extension, Router,
         body::Body,


### PR DESCRIPTION
Add a configurable ProxyType (via clap ValueEnum) selected by a new -p/--proxy CLI flag, replacing the hardcoded X-Real-IP lookup in the index handler. Closes #38.

Supported values:
  - cf-connecting-ip  -> read CF-Connecting-IP (Cloudflare)
  - x-forwarded-for   -> read the leftmost entry of the X-Forwarded-For
                         comma-separated list (original client convention)
  - x-real-ip         -> read X-Real-IP (default; preserves prior behavior)
  - none              -> ignore all headers and use the connected socket
                         address

The selected value is wired into the index handler with an axum::Extension<ProxyType> layer rather than refactoring the other handlers to a shared State, so endpoint_get_ip / endpoint_get_asn / endpoint_get_country are unchanged.

Side fix: the previous index handler called .unwrap() twice on the header value, so a malformed X-Real-IP would panic the request task. The new ProxyType::client_ip helper parses defensively and returns None on any malformed or absent header, letting the handler fall back to the connected socket address instead of crashing. A regression test (index_proxy_malformed_header_falls_back) covers this case.

Tests: updated the six existing index tests to inject the default Extension(ProxyType::XRealIp) and added six new tests covering the cf-connecting-ip, x-forwarded-for (single + multi-IP list), none, and malformed-header paths. cargo test --all-features -> 24 passed, 0 failed. cargo build --release clean; cargo clippy --all-features introduces no new warnings (the pre-existing "if args.experimental {}" empty-if warning is the documented placeholder).