### PR TITLE
fix: harden argo deployment manifests

### DIFF
--- a/manifests/argo/deployment.yaml
+++ b/manifests/argo/deployment.yaml
@@ -24,17 +24,32 @@ spec:
       containers:
       - name: ilrs-deployment
         image: neeythann/ip-location-rs:latest
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         resources:
           requests:
             cpu: 100m
             memory: 100Mi
           limits:
-            cpu: 100m
             memory: 100Mi
         ports:
         - containerPort: 80
           name: ilrs-http-port
-      restartPolicy: Always
+        readinessProbe:
+          httpGet:
+            path: /ip/1.1.1.1
+            port: 80
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          failureThreshold: 3
+        livenessProbe:
+          httpGet:
+            path: /ip/1.1.1.1
+            port: 80
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          failureThreshold: 3
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
 ---
 


### PR DESCRIPTION
- imagePullPolicy: IfNotPresent -> Always (avoids stale :latest cache)
- drop cpu limit (100m throttles under load); keep request
- add readiness/liveness probes (run.sh downloads MMDBs at startup)
- add container securityContext (runAsNonRoot, no privilege escalation)