### PR TITLE
fix: hoist license/modifications into a consistent top-level notes key

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ Which outputs:
   },
   "asn": {
     "autonomous_system_number": 13335,
-    "autonomous_system_organization": "Cloudflare, Inc.",
+    "autonomous_system_organization": "Cloudflare, Inc."
+  },
+  "notes": {
     "license": "CC BY 4.0 by RouteViews and DB-IP",
     "modifications": "https://github.com/sapics/ip-location-db/blob/main/asn/MODIFICATIONS"
   }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -116,6 +116,8 @@ components:
           oneOf:
             - $ref: '#/components/schemas/Asn'
             - type: "null"
+        notes:
+          $ref: '#/components/schemas/Notes'
 
     Asn:
       type: object
@@ -126,10 +128,6 @@ components:
         autonomous_system_organization:
           type: string
           example: Example Organization
-        license:
-          type: ["string", "null"]
-        modifications:
-          type: ["string", "null"]
 
     Country:
       type: object
@@ -137,6 +135,20 @@ components:
         country_code:
           type: string
           example: US
+
+    Notes:
+      type: object
+      description: >
+        Attribution metadata for the underlying MMDB data sources. Present on
+        every response so consumers always see the same `notes` shape
+        regardless of endpoint or whether the `asn` field is populated.
+      properties:
+        license:
+          type: ["string", "null"]
+          example: "CC BY 4.0 by RouteViews and DB-IP"
+        modifications:
+          type: ["string", "null"]
+          example: "https://github.com/sapics/ip-location-db/blob/main/asn/MODIFICATIONS"
 
     AsnResponse:
       type: object
@@ -148,6 +160,8 @@ components:
           items:
             type: string
             example: "192.0.2.0/24"
+        notes:
+          $ref: '#/components/schemas/Notes'
 
     CountryResponse:
       type: object
@@ -159,3 +173,5 @@ components:
           items:
             type: string
             example: "192.0.2.0/24"
+        notes:
+          $ref: '#/components/schemas/Notes'

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,7 +1,19 @@
-use crate::models::{Asn, Country, CountryResponse};
+use crate::models::{Asn, Country, CountryResponse, Notes};
 use maxminddb::Reader;
 use std::{collections::HashMap, fmt::Error, net::IpAddr};
 use tokio::sync::OnceCell;
+
+/// Attribution metadata for the underlying MMDB data sources. Returned on every
+/// API response so consumers always see the same `notes` shape regardless of
+/// endpoint or whether the `asn` field is populated.
+pub fn notes() -> Notes {
+    Notes {
+        license: Some(String::from("CC BY 4.0 by RouteViews and DB-IP")),
+        modifications: Some(String::from(
+            "https://github.com/sapics/ip-location-db/blob/main/asn/MODIFICATIONS",
+        )),
+    }
+}
 
 pub static IPV4_COUNTRY: OnceCell<Reader<Vec<u8>>> = OnceCell::const_new();
 pub static IPV4_ASN: OnceCell<Reader<Vec<u8>>> = OnceCell::const_new();
@@ -37,21 +49,11 @@ pub fn get_asn(ip: IpAddr) -> Option<Asn> {
         IpAddr::V4(_) => IPV4_ASN.get().unwrap(),
         IpAddr::V6(_) => IPV6_ASN.get().unwrap(),
     };
-    match reader
+    reader
         .lookup(ip)
         .expect("Invalid IP address!")
         .decode::<Asn>()
         .unwrap()
-    {
-        Some(mut asn) => {
-            asn.license = Some(String::from("CC BY 4.0 by RouteViews and DB-IP"));
-            asn.modifications = Some(String::from(
-                "https://github.com/sapics/ip-location-db/blob/main/asn/MODIFICATIONS",
-            ));
-            Some(asn)
-        }
-        None => None,
-    }
 }
 
 pub async fn init_mmdb() {
@@ -98,6 +100,7 @@ pub async fn init_country_cache() {
                     .or_insert_with(|| CountryResponse {
                         country: country_data,
                         networks: Some(vec![network]),
+                        notes: notes(),
                     });
             }
 
@@ -124,6 +127,7 @@ pub async fn init_country_cache() {
                     .or_insert_with(|| CountryResponse {
                         country: country_data,
                         networks: Some(vec![network]),
+                        notes: notes(),
                     });
             }
 

--- a/src/handlers/ip.rs
+++ b/src/handlers/ip.rs
@@ -41,11 +41,11 @@ pub async fn endpoint_get_ip(Path(ip): Path<IpAddr>) -> Result<Json<RequestedAdd
             {
                 return Err(StatusCode::UNSUPPORTED_MEDIA_TYPE);
             }
-            Ok(Json(RequestedAddress {
+            Ok(Json(RequestedAddress::new(
                 ip,
-                country: get_country(ip),
-                asn: get_asn(ip),
-            }))
+                get_country(ip),
+                get_asn(ip),
+            )))
         }
         IpAddr::V6(ipv6) => {
             if ipv6.is_loopback()
@@ -56,11 +56,11 @@ pub async fn endpoint_get_ip(Path(ip): Path<IpAddr>) -> Result<Json<RequestedAdd
             {
                 return Err(StatusCode::UNSUPPORTED_MEDIA_TYPE);
             }
-            Ok(Json(RequestedAddress {
+            Ok(Json(RequestedAddress::new(
                 ip,
-                country: get_country(ip),
-                asn: get_asn(ip),
-            }))
+                get_country(ip),
+                get_asn(ip),
+            )))
         }
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -5,8 +5,6 @@ use std::net::IpAddr;
 pub struct Asn {
     pub autonomous_system_number: usize,
     pub autonomous_system_organization: String,
-    pub license: Option<String>,
-    pub modifications: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -14,11 +12,18 @@ pub struct Country {
     pub country_code: String,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Notes {
+    pub license: Option<String>,
+    pub modifications: Option<String>,
+}
+
 #[derive(Serialize)]
 pub struct RequestedAddress {
     pub ip: IpAddr,
     pub country: Option<Country>,
     pub asn: Option<Asn>,
+    pub notes: Notes,
 }
 
 impl RequestedAddress {
@@ -27,6 +32,7 @@ impl RequestedAddress {
             ip,
             country: None,
             asn: None,
+            notes: crate::db::notes(),
         }
     }
 
@@ -42,6 +48,7 @@ impl RequestedAddress {
 pub struct AsnResponse {
     pub asn: Asn,
     pub networks: Option<Vec<String>>,
+    pub notes: Notes,
 }
 
 impl AsnResponse {
@@ -50,7 +57,11 @@ impl AsnResponse {
     }
 
     pub fn new(asn: Asn, networks: Option<Vec<String>>) -> Self {
-        AsnResponse { asn, networks }
+        AsnResponse {
+            asn,
+            networks,
+            notes: crate::db::notes(),
+        }
     }
 }
 
@@ -58,4 +69,5 @@ impl AsnResponse {
 pub struct CountryResponse {
     pub country: Country,
     pub networks: Option<Vec<String>>,
+    pub notes: Notes,
 }


### PR DESCRIPTION
Previously the license and modifications attribution strings lived inside the Asn struct, which made the API responses inconsistent:

  - On / and /ip/{ip} they were nested under asn and disappeared entirely when asn was null.
  - On /AS/{asn} they were nested under asn.
  - On /country/{country_code} they were absent altogether because the Country struct had no such fields.

This left every endpoint returning a different shape and made the attribution data vanish whenever an IP had no ASN data.

Introduce a dedicated Notes { license, modifications } struct and a single db::notes() helper that owns the attribution strings (the source of truth, previously hardcoded inside get_asn). Add a notes field to RequestedAddress, AsnResponse, and CountryResponse so every endpoint returns the same top-level notes key regardless of whether asn is populated.

Changes:
  - src/models.rs: drop license/modifications from Asn; add the Notes struct; add a notes field to all three response structs; populate it in the RequestedAddress and AsnResponse constructors.
  - src/db.rs: stop mutating Asn in get_asn; expose pub fn notes() as the single source of the attribution strings; populate notes when building CountryResponse entries in init_country_cache (both ipv4 and ipv6 branches).
  - src/handlers/ip.rs: build RequestedAddress via ::new in endpoint_get_ip so the notes field is populated (the struct literals previously used did not set it).
  - openapi.yaml: remove license/modifications from the Asn schema; add a Notes schema component and $ref it from RequestedAddress, AsnResponse, and CountryResponse.
  - README.md: update the sample JSON to the new shape.

Verified with cargo build --release, cargo clippy --all-targets --all-features (no new warnings; pre-existing warnings unchanged), and cargo test --all-features (24/24 passing). A manual smoke test against the running binary confirms all four endpoints (/, /ip/{ip}, /AS/{asn}, /country/{cc}) now return an identical top-level notes object.