### PR TITLE
feat: pretty-print JSON responses on all endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,6 +356,7 @@ dependencies = [
  "ipnetwork",
  "maxminddb",
  "serde",
+ "serde_json",
  "tokio",
  "tower",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ clap = {version = "4.5.36", features = ["derive"]}
 ipnetwork = "0.21.1"
 maxminddb = "0.27.0"
 serde = {version = "1.0.219", features = ["derive"]}
+serde_json = "1.0"
 tokio = {version = "1.44.1", features = ["full"]}
 tracing = "0.1.41"
 tracing-subscriber = "0.3.20"

--- a/src/handlers/asn.rs
+++ b/src/handlers/asn.rs
@@ -1,13 +1,14 @@
 use crate::db::{IPV4_ASN, IPV6_ASN};
+use crate::handlers::PrettyJson;
 use crate::models::{Asn, AsnResponse};
-use axum::{Json, extract::Path, http::StatusCode};
+use axum::{extract::Path, http::StatusCode};
 use ipnetwork::IpNetwork;
 use tokio::task::yield_now;
 
 // TODO(neeythann):
 // - validate Path(asn)
 // - cache this result at startup
-pub async fn endpoint_get_asn(Path(asn): Path<usize>) -> Result<Json<AsnResponse>, StatusCode> {
+pub async fn endpoint_get_asn(Path(asn): Path<usize>) -> Result<PrettyJson<AsnResponse>, StatusCode> {
     let network4: IpNetwork = "0.0.0.0/0".parse().unwrap();
     let network6: IpNetwork = "::0/0".parse().unwrap();
     let mut net: Vec<String> = vec![];
@@ -57,5 +58,5 @@ pub async fn endpoint_get_asn(Path(asn): Path<usize>) -> Result<Json<AsnResponse
         return Err(StatusCode::BAD_REQUEST);
     }
 
-    Ok(Json(AsnResponse::new(asn_info.unwrap(), Some(net))))
+    Ok(PrettyJson(AsnResponse::new(asn_info.unwrap(), Some(net))))
 }

--- a/src/handlers/asn.rs
+++ b/src/handlers/asn.rs
@@ -8,7 +8,9 @@ use tokio::task::yield_now;
 // TODO(neeythann):
 // - validate Path(asn)
 // - cache this result at startup
-pub async fn endpoint_get_asn(Path(asn): Path<usize>) -> Result<PrettyJson<AsnResponse>, StatusCode> {
+pub async fn endpoint_get_asn(
+    Path(asn): Path<usize>,
+) -> Result<PrettyJson<AsnResponse>, StatusCode> {
     let network4: IpNetwork = "0.0.0.0/0".parse().unwrap();
     let network6: IpNetwork = "::0/0".parse().unwrap();
     let mut net: Vec<String> = vec![];

--- a/src/handlers/country.rs
+++ b/src/handlers/country.rs
@@ -1,16 +1,17 @@
 use crate::db::COUNTRY_CACHE;
+use crate::handlers::PrettyJson;
 use crate::models::CountryResponse;
-use axum::{Json, extract::Path, http::StatusCode};
+use axum::{extract::Path, http::StatusCode};
 
 pub async fn endpoint_get_country(
     Path(country_code): Path<String>,
-) -> Result<Json<CountryResponse>, StatusCode> {
+) -> Result<PrettyJson<CountryResponse>, StatusCode> {
     if country_code.len() != 2 || !country_code.bytes().all(|c| matches!(c, b'A'..=b'Z')) {
         return Err(StatusCode::BAD_REQUEST);
     }
 
     match COUNTRY_CACHE.get().unwrap().get(&country_code) {
-        Some(resp) => Ok(Json(resp.clone())),
+        Some(resp) => Ok(PrettyJson(resp.clone())),
         None => Err(StatusCode::BAD_REQUEST),
     }
 }

--- a/src/handlers/ip.rs
+++ b/src/handlers/ip.rs
@@ -1,8 +1,9 @@
 use crate::ProxyType;
 use crate::db::{get_asn, get_country};
+use crate::handlers::PrettyJson;
 use crate::models::RequestedAddress;
 use axum::{
-    Extension, Json,
+    Extension,
     extract::{ConnectInfo, Path},
     http::{HeaderMap, StatusCode},
 };
@@ -21,17 +22,19 @@ pub async fn index(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     Extension(proxy): Extension<ProxyType>,
     headers: HeaderMap,
-) -> Result<Json<RequestedAddress>, StatusCode> {
+) -> Result<PrettyJson<RequestedAddress>, StatusCode> {
     let ip = proxy.client_ip(&headers).unwrap_or_else(|| addr.ip());
 
-    Ok(Json(RequestedAddress::new(
+    Ok(PrettyJson(RequestedAddress::new(
         ip,
         get_country(ip),
         get_asn(ip),
     )))
 }
 
-pub async fn endpoint_get_ip(Path(ip): Path<IpAddr>) -> Result<Json<RequestedAddress>, StatusCode> {
+pub async fn endpoint_get_ip(
+    Path(ip): Path<IpAddr>,
+) -> Result<PrettyJson<RequestedAddress>, StatusCode> {
     match ip {
         IpAddr::V4(ipv4) => {
             if ipv4.is_loopback()
@@ -41,7 +44,7 @@ pub async fn endpoint_get_ip(Path(ip): Path<IpAddr>) -> Result<Json<RequestedAdd
             {
                 return Err(StatusCode::UNSUPPORTED_MEDIA_TYPE);
             }
-            Ok(Json(RequestedAddress::new(
+            Ok(PrettyJson(RequestedAddress::new(
                 ip,
                 get_country(ip),
                 get_asn(ip),
@@ -56,7 +59,7 @@ pub async fn endpoint_get_ip(Path(ip): Path<IpAddr>) -> Result<Json<RequestedAdd
             {
                 return Err(StatusCode::UNSUPPORTED_MEDIA_TYPE);
             }
-            Ok(Json(RequestedAddress::new(
+            Ok(PrettyJson(RequestedAddress::new(
                 ip,
                 get_country(ip),
                 get_asn(ip),

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,3 +1,19 @@
+use axum::response::{IntoResponse, Response};
+use serde::Serialize;
+
 pub mod asn;
 pub mod country;
 pub mod ip;
+
+pub struct PrettyJson<T>(pub T);
+
+impl<T: Serialize> IntoResponse for PrettyJson<T> {
+    fn into_response(self) -> Response {
+        let body = serde_json::to_string_pretty(&self.0).expect("failed to serialize response");
+        (
+            [(axum::http::header::CONTENT_TYPE, "application/json")],
+            body,
+        )
+            .into_response()
+    }
+}


### PR DESCRIPTION
Replace axum::Json (compact serialization) with a PrettyJson<T> wrapper in src/handlers/mod.rs that uses serde_json::to_string_pretty, producing 2-space-indented, multi-line JSON for human readability.

- Add serde_json = "1.0" to Cargo.toml (was already pulled in transitively via axum; this promotes it to a direct dependency).
- Introduce PrettyJson<T> with IntoResponse impl mirroring axum::Json's Content-Type (application/json) but emitting pretty-printed bodies.
- Swap Json<T> -> PrettyJson<T> across all four success handlers: index and endpoint_get_ip in src/handlers/ip.rs, endpoint_get_asn in src/handlers/asn.rs, endpoint_get_country in src/handlers/country.rs.
- Error responses (Err(StatusCode)) are unchanged; they carry no body.

Verified with cargo build --release, cargo test --all-features (24/24 passing), and a live curl confirming the new 2-space-indented output and the application/json Content-Type header.