### PR TITLE
feat: allow --proxy to be set via PROXY_TYPE env var

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/neeythann/ip-location-rs"
 
 [dependencies]
 axum = "0.8.3"
-clap = {version = "4.5.36", features = ["derive"]}
+clap = {version = "4.5.36", features = ["derive", "env"]}
 ipnetwork = "0.21.1"
 maxminddb = "0.27.0"
 serde = {version = "1.0.219", features = ["derive"]}

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,11 @@
 # NOTE: please read DPIP-LICENSE and ROUTEVIEWS-LICENSE before continuing
 # This bash script is ONLY invoked in the starting point of the docker container
+#
+# PROXY_TYPE can be set in the container environment to configure which
+# header ip-location-rs trusts for the client's real IP on the index
+# endpoint (cf-connecting-ip, x-forwarded-for, x-real-ip, or none). It is
+# read natively by the binary via clap's env support, so it just needs to
+# be present in the environment when /app/ip-location-rs runs.
 
 wget https://cdn.jsdelivr.net/npm/@ip-location-db/asn-country-mmdb/asn-country-ipv4.mmdb
 wget https://cdn.jsdelivr.net/npm/@ip-location-db/asn-country-mmdb/asn-country-ipv6.mmdb

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,10 +75,12 @@ struct Args {
         short,
         long,
         value_enum,
+        env = "PROXY_TYPE",
         default_value_t = ProxyType::XRealIp,
         help = "Which request header to trust for the client's real IP on the \
                 index endpoint (also accepts `none` to ignore headers and use \
-                the socket address)"
+                the socket address). Can also be set via the PROXY_TYPE \
+                environment variable."
     )]
     proxy: ProxyType,
 }


### PR DESCRIPTION
Enables configuring the trusted client-IP header through the container environment instead of only via the CLI flag, since run.sh's Docker entrypoint doesn't take CLI args.