### PR TITLE
perf: cache /AS/{asn} responses at startup

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1,4 +1,4 @@
-use crate::models::{Asn, Country, CountryResponse, Notes};
+use crate::models::{Asn, AsnResponse, Country, CountryResponse, Notes};
 use maxminddb::Reader;
 use std::{collections::HashMap, fmt::Error, net::IpAddr};
 use tokio::sync::OnceCell;
@@ -22,6 +22,7 @@ pub static IPV6_COUNTRY: OnceCell<Reader<Vec<u8>>> = OnceCell::const_new();
 pub static IPV6_ASN: OnceCell<Reader<Vec<u8>>> = OnceCell::const_new();
 
 pub static COUNTRY_CACHE: OnceCell<HashMap<String, CountryResponse>> = OnceCell::const_new();
+pub static ASN_CACHE: OnceCell<HashMap<usize, AsnResponse>> = OnceCell::const_new();
 
 async fn init_reader(path: impl AsRef<std::path::Path>) -> Result<Reader<Vec<u8>>, Error> {
     let content = tokio::fs::read(path).await.unwrap();
@@ -126,6 +127,70 @@ pub async fn init_country_cache() {
                     })
                     .or_insert_with(|| CountryResponse {
                         country: country_data,
+                        networks: Some(vec![network]),
+                        notes: notes(),
+                    });
+            }
+
+            cache
+        })
+        .await;
+}
+
+pub async fn init_asn_cache() {
+    ASN_CACHE
+        .get_or_init(|| async {
+            let mut cache: HashMap<usize, AsnResponse> = HashMap::new();
+
+            let network4: ipnetwork::IpNetwork = "0.0.0.0/0".parse().unwrap();
+            let mut iter = IPV4_ASN
+                .get()
+                .unwrap()
+                .within(network4, Default::default())
+                .unwrap();
+            while let Some(next) = iter.next() {
+                let lookup = next.unwrap();
+                let asn_data: Asn = match lookup.decode() {
+                    Ok(Some(data)) => data,
+                    _ => continue,
+                };
+                let network = lookup.network().unwrap().to_string();
+                cache
+                    .entry(asn_data.autonomous_system_number)
+                    .and_modify(|resp| {
+                        if let Some(nets) = resp.networks.as_mut() {
+                            nets.push(network.clone());
+                        }
+                    })
+                    .or_insert_with(|| AsnResponse {
+                        asn: asn_data,
+                        networks: Some(vec![network]),
+                        notes: notes(),
+                    });
+            }
+
+            let network6: ipnetwork::IpNetwork = "::0/0".parse().unwrap();
+            iter = IPV6_ASN
+                .get()
+                .unwrap()
+                .within(network6, Default::default())
+                .unwrap();
+            while let Some(next) = iter.next() {
+                let lookup = next.unwrap();
+                let asn_data: Asn = match lookup.decode() {
+                    Ok(Some(data)) => data,
+                    _ => continue,
+                };
+                let network = lookup.network().unwrap().to_string();
+                cache
+                    .entry(asn_data.autonomous_system_number)
+                    .and_modify(|resp| {
+                        if let Some(nets) = resp.networks.as_mut() {
+                            nets.push(network.clone());
+                        }
+                    })
+                    .or_insert_with(|| AsnResponse {
+                        asn: asn_data,
                         networks: Some(vec![network]),
                         notes: notes(),
                     });

--- a/src/handlers/asn.rs
+++ b/src/handlers/asn.rs
@@ -1,64 +1,15 @@
-use crate::db::{IPV4_ASN, IPV6_ASN};
+use crate::db::ASN_CACHE;
 use crate::handlers::PrettyJson;
-use crate::models::{Asn, AsnResponse};
+use crate::models::AsnResponse;
 use axum::{extract::Path, http::StatusCode};
-use ipnetwork::IpNetwork;
-use tokio::task::yield_now;
 
 // TODO(neeythann):
 // - validate Path(asn)
-// - cache this result at startup
 pub async fn endpoint_get_asn(
     Path(asn): Path<usize>,
 ) -> Result<PrettyJson<AsnResponse>, StatusCode> {
-    let network4: IpNetwork = "0.0.0.0/0".parse().unwrap();
-    let network6: IpNetwork = "::0/0".parse().unwrap();
-    let mut net: Vec<String> = vec![];
-
-    let mut asn_info: Option<Asn> = None;
-
-    let mut iter = IPV4_ASN
-        .get()
-        .unwrap()
-        .within(network4, Default::default())
-        .unwrap();
-    while let Some(next) = iter.next() {
-        let lookup = next.unwrap();
-        let asn_data: Asn = match lookup.decode() {
-            Ok(Some(data)) => data,
-            _ => continue,
-        };
-        if asn_data.autonomous_system_number != asn {
-            continue;
-        }
-
-        if asn_info.is_none() {
-            asn_info = Some(asn_data.clone());
-        }
-        net.push(lookup.network().unwrap().to_string());
-        yield_now().await;
+    match ASN_CACHE.get().unwrap().get(&asn) {
+        Some(resp) => Ok(PrettyJson(resp.clone())),
+        None => Err(StatusCode::BAD_REQUEST),
     }
-    iter = IPV6_ASN
-        .get()
-        .unwrap()
-        .within(network6, Default::default())
-        .unwrap();
-    while let Some(next) = iter.next() {
-        let lookup = next.unwrap();
-        let asn_data: Asn = match lookup.decode() {
-            Ok(Some(data)) => data,
-            _ => continue,
-        };
-        if asn_data.autonomous_system_number != asn {
-            continue;
-        }
-        net.push(lookup.network().unwrap().to_string());
-        yield_now().await;
-    }
-
-    if asn_info.is_none() {
-        return Err(StatusCode::BAD_REQUEST);
-    }
-
-    Ok(PrettyJson(AsnResponse::new(asn_info.unwrap(), Some(net))))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,6 +96,7 @@ async fn main() {
 
     db::init_mmdb().await;
     db::init_country_cache().await;
+    db::init_asn_cache().await;
 
     let routes = Router::new()
         .route("/", get(index))
@@ -436,6 +437,7 @@ mod tests {
     #[tokio::test]
     async fn asn_valid() {
         init_mmdb().await;
+        crate::db::init_asn_cache().await;
         let app = Router::new()
             .route("/AS/{asn_number}", get(endpoint_get_asn))
             .into_service::<Body>();
@@ -453,6 +455,7 @@ mod tests {
     #[tokio::test]
     async fn asn_invalid_number() {
         init_mmdb().await;
+        crate::db::init_asn_cache().await;
         let app = Router::new()
             .route("/AS/{asn_number}", get(endpoint_get_asn))
             .into_service::<Body>();
@@ -470,6 +473,7 @@ mod tests {
     #[tokio::test]
     async fn asn_invalid_type() {
         init_mmdb().await;
+        crate::db::init_asn_cache().await;
         let app = Router::new()
             .route("/AS/{asn_number}", get(endpoint_get_asn))
             .into_service::<Body>();


### PR DESCRIPTION
/AS/{asn} previously ran a full linear scan of both ASN mmdb tries on every request. Mirror the existing COUNTRY_CACHE pattern: build an ASN_CACHE keyed by ASN number once at startup, and reduce the handler to a HashMap lookup.

This also fixes a pre-existing bug where ASNs with only IPv6 announcements (no IPv4 presence) incorrectly returned 400 — the old scan only ever set the returned ASN metadata inside the IPv4 loop.